### PR TITLE
Fixed footer

### DIFF
--- a/scroll-progress-bar/assets/css/styles.css
+++ b/scroll-progress-bar/assets/css/styles.css
@@ -11,11 +11,23 @@
 #readTime {
     display: block;
     overflow: hidden;
-    position: fixed;
     opacity: 0.4;
     color: green;
+    text-align: center;
 }
 
 .content {
     padding-top: 30px;
+    padding-bottom: 50px;
+}
+
+#footer {
+    position: fixed;
+    height: 50px;
+    background-color: #fff;
+    box-shadow: 0px 0 10px rgba(0, 0, 0, 0.2);
+    bottom: 0px;
+    left: 0px;
+    right: 0px;
+    margin-bottom: 0px;
 }

--- a/scroll-progress-bar/assets/js/scripts.js
+++ b/scroll-progress-bar/assets/js/scripts.js
@@ -17,17 +17,15 @@ window.onresize = function(){
 
 window.onscroll = function getYOffset() {
     let scrollOffsetPx = window.pageYOffset;
-    let screenWidthSetting = (scrollOffsetPx / (contentHeight - screenHeight)) * 100; //Calculates (Pixels from top edge of screen / (Height of content - total height of viewport) Ex. 40% = (200 / (1000 - 500)) 
+    let screenWidthSetting = Math.round(scrollOffsetPx / (contentHeight - screenHeight) * 100); //Calculates (Pixels from top edge of screen / (Height of content - total height of viewport) Ex. 40% = (200 / (1000 - 500)) 
     scrollBar.style.minWidth = "1%"; // Sets default value
 
-    let minutesLeft = Math.round(minutesOfReading * (screenWidthSetting / 100));     //Calculates minutes of reading remaining by piggybacking off screen width percentage(screenWidthSetting) EX: (19 * (100 / 100) = 19
+    let minutesLeft = minutesOfReading * (screenWidthSetting / 100);     //Calculates minutes of reading remaining by piggybacking off screen width percentage(screenWidthSetting) EX: (19 * (100 / 100) = 19
     minutesLeft = parseInt(minutesOfReading - minutesLeft); // Gets inverse of minutesLeft Ex: 19 - 14 = 5 minutes left - so counter counts down instead of up
-    console.log(minutesLeft);
     readTimeLabel.innerHTML = "Read Time: " + minutesLeft + " Minutes" ;
     
     if (screenWidthSetting <= 100) {
         scrollBar.style.width = screenWidthSetting + "%";
-        readTimeLabel.style.top = screenWidthSetting + "%";
     } else {
         scrollBar.style.width = "100%"
     }

--- a/scroll-progress-bar/assets/js/scripts.js
+++ b/scroll-progress-bar/assets/js/scripts.js
@@ -11,7 +11,7 @@ let minutesOfReading = parseInt(wordCount / 130);
 readTimeLabel.innerHTML = "Read Time: " + minutesOfReading + " Minutes"; //sets value on page load
 
 window.onresize = function(){
-    contentHeight = content.offsetHeight;
+    contentHeight = content.offsetHeight; //offsetHeight includes height of element including padding/borders. #Footer does not need to be included in calculations because #content has a bottom-padding: 50px;
     screenHeight = window.screen.height;
 };
 

--- a/scroll-progress-bar/index.html
+++ b/scroll-progress-bar/index.html
@@ -14,7 +14,6 @@
   <body>
     <div id="scrollBar"></div>
     <div class="container">
-      <h2 id="readTime">Read Time: </h2>
     <div class="content">
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec laoreet odio sit amet lectus elementum, id gravida elit efficitur. Donec sapien nibh, dictum tempus scelerisque ac, mattis commodo quam. Nulla ipsum dui, convallis quis auctor id, luctus non leo. Sed vel ex tortor. Aenean porttitor felis nunc. Quisque consequat a purus ut rhoncus. Nunc maximus, augue nec fringilla molestie, arcu risus interdum arcu, nec viverra mi magna sed risus. Nullam eleifend, nulla vitae cursus auctor, magna lorem elementum justo, non tempor sem erat a risus. Phasellus consequat consectetur dolor. Nam vel massa eu odio blandit commodo non eget arcu. Donec mollis, massa vel laoreet lobortis, purus odio laoreet nulla, ut tincidunt libero dui sagittis metus.
@@ -78,6 +77,9 @@
     
       Nunc rutrum eros eu suscipit aliquam. Sed porta, lorem eget pharetra mollis, elit felis dictum magna, in venenatis nisl metus ac sapien. Nulla sed erat posuere, rutrum erat a, viverra dolor. Proin ut odio interdum, rutrum diam sed, lacinia justo. Morbi congue lacinia urna eget posuere. Aliquam pharetra dui a arcu tempor finibus. Donec ullamcorper vitae mauris non iaculis. Ut dictum tempus lacus accumsan bibendum. Ut porta orci eget purus ullamcorper aliquam. Curabitur a pharetra nulla. Morbi sollicitudin dolor at facilisis scelerisque. Fusce posuere consequat iaculis. Maecenas non nibh mi. Aenean sapien orci, volutpat vel tristique nec, elementum rhoncus orci. Sed condimentum orci quis velit tempor, quis accumsan nibh bibendum.
       </p>
+      <div id="footer">
+        <h2 id="readTime">Read Time: </h2>
+      </div>
     </div>
     </div>
 


### PR DESCRIPTION
Previous Functionality:
The read time label initially functioned in conjunction with the progress bar. For every increment of the progress bar, the read time label would progress either up or down the viewport at the same increment.

Goals:
- Make read time label into sticky footer
- Prevent sticky footer from overlapping content
- Account for extra space created by footer in calculations of screenWidthSetting

Implementation:
- Moved footer below "#content" for better organization
- styled sticky footer to always stay at the bottom of the browser's viewport
- Removed logic that positioned readTimeLabel 's top attribute

Notes: No additional calculations had to be made to account for the height of the footer since "#content" has bottom-padding: 50px, and the height of "#footer" is 50px. let contentHeight = content.offsetHeight," returns the height of an element, including vertical padding and borders, as an integer." 